### PR TITLE
Add .adl screens for MxSampleDetect

### DIFF
--- a/adPythonApp/opi/adl/adPythonMxSampleDetect.adl
+++ b/adPythonApp/opi/adl/adPythonMxSampleDetect.adl
@@ -1,0 +1,1108 @@
+
+file {
+	name="adPythonMxSampleDetect.adl"
+	version=030109
+}
+display {
+	object {
+		x=314
+		y=582
+		width=1245
+		height=627
+	}
+	clr=14
+	bclr=4
+	cmap=""
+	gridSpacing=5
+	gridOn=0
+	snapToGrid=0
+}
+"color map" {
+	ncolors=65
+	colors {
+		ffffff,
+		ececec,
+		dadada,
+		c8c8c8,
+		bbbbbb,
+		aeaeae,
+		9e9e9e,
+		919191,
+		858585,
+		787878,
+		696969,
+		5a5a5a,
+		464646,
+		2d2d2d,
+		000000,
+		00d800,
+		1ebb00,
+		339900,
+		2d7f00,
+		216c00,
+		fd0000,
+		de1309,
+		be190b,
+		a01207,
+		820400,
+		5893ff,
+		597ee1,
+		4b6ec7,
+		3a5eab,
+		27548d,
+		fbf34a,
+		f9da3c,
+		eeb62b,
+		e19015,
+		cd6100,
+		ffb0ff,
+		d67fe2,
+		ae4ebc,
+		8b1a96,
+		610a75,
+		a4aaff,
+		8793e2,
+		6a73c1,
+		4d52a4,
+		343386,
+		c7bb6d,
+		b79d5c,
+		a47e3c,
+		7d5627,
+		58340f,
+		99ffff,
+		73dfff,
+		4ea5f9,
+		2a63e4,
+		0a00b8,
+		ebf1b5,
+		d4db9d,
+		bbc187,
+		a6a462,
+		8b8239,
+		73ff6b,
+		52da3b,
+		3cb420,
+		289315,
+		1a7309,
+	}
+}
+rectangle {
+	object {
+		x=0
+		y=4
+		width=1245
+		height=25
+	}
+	"basic attribute" {
+		clr=2
+	}
+}
+text {
+	object {
+		x=0
+		y=5
+		width=1245
+		height=25
+	}
+	"basic attribute" {
+		clr=54
+	}
+	textix="$(P)$(R)"
+	align="horiz. centered"
+}
+composite {
+	object {
+		x=5
+		y=66
+		width=380
+		height=555
+	}
+	"composite name"=""
+	"composite file"="NDPluginBase.adl"
+}
+composite {
+	object {
+		x=391
+		y=35
+		width=848
+		height=184
+	}
+	"composite name"=""
+	"composite file"="adPythonPlugin.adl"
+}
+text {
+	object {
+		x=848
+		y=289
+		width=120
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Tip X"
+	align="horiz. right"
+}
+"related display" {
+	object {
+		x=976
+		y=339
+		width=130
+		height=20
+	}
+	display[0] {
+		label="Edge Arrays"
+		name="adPythonMxSampleDetectPlot.adl"
+		args="P=$(P),R=$(R)"
+	}
+	clr=14
+	bclr=51
+	label=" "
+}
+text {
+	object {
+		x=848
+		y=399
+		width=120
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Image"
+	align="horiz. right"
+}
+rectangle {
+	object {
+		x=936
+		y=227
+		width=207
+		height=21
+	}
+	"basic attribute" {
+		clr=2
+	}
+}
+text {
+	object {
+		x=939
+		y=228
+		width=200
+		height=20
+	}
+	"basic attribute" {
+		clr=54
+	}
+	textix="Sample Detect Output"
+	align="horiz. centered"
+}
+menu {
+	object {
+		x=976
+		y=459
+		width=130
+		height=20
+	}
+	control {
+		chan="$(P)$(R)DrawTip"
+		clr=14
+		bclr=51
+	}
+}
+"text update" {
+	object {
+		x=1112
+		y=460
+		width=120
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)DrawTip_RBV"
+		clr=54
+		bclr=4
+	}
+	format="string"
+	limits {
+	}
+}
+text {
+	object {
+		x=848
+		y=459
+		width=120
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Tip"
+	align="horiz. right"
+}
+menu {
+	object {
+		x=976
+		y=399
+		width=130
+		height=20
+	}
+	control {
+		chan="$(P)$(R)OutputArray"
+		clr=14
+		bclr=51
+	}
+}
+"text update" {
+	object {
+		x=1112
+		y=400
+		width=120
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)OutputArray_RBV"
+		clr=54
+		bclr=4
+	}
+	format="string"
+	limits {
+	}
+}
+rectangle {
+	object {
+		x=834
+		y=225
+		width=405
+		height=396
+	}
+	"basic attribute" {
+		clr=14
+		fill="outline"
+	}
+}
+"text update" {
+	object {
+		x=976
+		y=290
+		width=130
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)TipX"
+		clr=54
+		bclr=4
+	}
+	format="string"
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=976
+		y=315
+		width=130
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)TipY"
+		clr=54
+		bclr=4
+	}
+	format="string"
+	limits {
+	}
+}
+text {
+	object {
+		x=848
+		y=314
+		width=120
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Tip Y"
+	align="horiz. right"
+}
+text {
+	object {
+		x=848
+		y=339
+		width=120
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Edges"
+	align="horiz. right"
+}
+text {
+	object {
+		x=1112
+		y=342
+		width=120
+		height=14
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="(Upside down)"
+}
+text {
+	object {
+		x=841
+		y=259
+		width=120
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Tips & Edges"
+}
+text {
+	object {
+		x=848
+		y=484
+		width=120
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Edges"
+	align="horiz. right"
+}
+menu {
+	object {
+		x=976
+		y=484
+		width=130
+		height=20
+	}
+	control {
+		chan="$(P)$(R)DrawEdges"
+		clr=14
+		bclr=51
+	}
+}
+"text update" {
+	object {
+		x=1112
+		y=485
+		width=120
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)DrawEdges_RBV"
+		clr=54
+		bclr=4
+	}
+	format="string"
+	limits {
+	}
+}
+menu {
+	object {
+		x=976
+		y=509
+		width=130
+		height=20
+	}
+	control {
+		chan="$(P)$(R)ForceColor"
+		clr=14
+		bclr=51
+	}
+}
+text {
+	object {
+		x=848
+		y=509
+		width=120
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Force colour"
+	align="horiz. right"
+}
+"text update" {
+	object {
+		x=1112
+		y=510
+		width=120
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)ForceColor_RBV"
+		clr=54
+		bclr=4
+	}
+	format="string"
+	limits {
+	}
+}
+text {
+	object {
+		x=841
+		y=369
+		width=120
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Image Select"
+}
+text {
+	object {
+		x=841
+		y=429
+		width=170
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Image Annotations"
+}
+"text update" {
+	object {
+		x=701
+		y=290
+		width=120
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)Preprocess_RBV"
+		clr=54
+		bclr=4
+	}
+	format="string"
+	limits {
+	}
+}
+menu {
+	object {
+		x=565
+		y=289
+		width=130
+		height=20
+	}
+	control {
+		chan="$(P)$(R)Preprocess"
+		clr=14
+		bclr=51
+	}
+}
+rectangle {
+	object {
+		x=391
+		y=225
+		width=437
+		height=396
+	}
+	"basic attribute" {
+		clr=14
+		fill="outline"
+	}
+}
+rectangle {
+	object {
+		x=503
+		y=227
+		width=217
+		height=21
+	}
+	"basic attribute" {
+		clr=2
+	}
+}
+text {
+	object {
+		x=506
+		y=228
+		width=210
+		height=20
+	}
+	"basic attribute" {
+		clr=54
+	}
+	textix="Sample Detect Process"
+	align="horiz. centered"
+}
+text {
+	object {
+		x=398
+		y=259
+		width=100
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Preprocess"
+}
+text {
+	object {
+		x=405
+		y=289
+		width=150
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Preprocess"
+	align="horiz. right"
+}
+"text update" {
+	object {
+		x=405
+		y=314
+		width=150
+		height=20
+	}
+	monitor {
+		chan="$(P)$(R)PpParam1Name"
+		clr=14
+		bclr=4
+	}
+	align="horiz. right"
+	format="string"
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=565
+		y=314
+		width=130
+		height=20
+	}
+	control {
+		chan="$(P)$(R)PpParam1"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=701
+		y=315
+		width=120
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)PpParam1_RBV"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=405
+		y=339
+		width=150
+		height=20
+	}
+	monitor {
+		chan="$(P)$(R)PpParam2Name"
+		clr=14
+		bclr=4
+	}
+	align="horiz. right"
+	format="string"
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=565
+		y=339
+		width=130
+		height=20
+	}
+	control {
+		chan="$(P)$(R)PpParam2"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=701
+		y=340
+		width=120
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)PpParam2_RBV"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+text {
+	object {
+		x=398
+		y=369
+		width=270
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Canny Edge Detect Threshold"
+}
+"text entry" {
+	object {
+		x=565
+		y=399
+		width=130
+		height=20
+	}
+	control {
+		chan="$(P)$(R)CannyUpper"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=701
+		y=400
+		width=120
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)CannyUpper_RBV"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=565
+		y=424
+		width=130
+		height=20
+	}
+	control {
+		chan="$(P)$(R)CannyLower"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=701
+		y=425
+		width=120
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)CannyLower_RBV"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+text {
+	object {
+		x=405
+		y=399
+		width=150
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Upper (0-255)"
+	align="horiz. right"
+}
+text {
+	object {
+		x=405
+		y=424
+		width=150
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Lower (0-255)"
+	align="horiz. right"
+}
+text {
+	object {
+		x=398
+		y=454
+		width=310
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="'Close' Morphological Operation"
+}
+"text entry" {
+	object {
+		x=565
+		y=484
+		width=130
+		height=20
+	}
+	control {
+		chan="$(P)$(R)CloseKsize"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=701
+		y=485
+		width=120
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)CloseKsize_RBV"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=565
+		y=509
+		width=130
+		height=20
+	}
+	control {
+		chan="$(P)$(R)CloseIterations"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=701
+		y=510
+		width=120
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)CloseIterations_RBV"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+text {
+	object {
+		x=405
+		y=484
+		width=150
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="ksize (px)"
+	align="horiz. right"
+}
+text {
+	object {
+		x=405
+		y=509
+		width=150
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Iterations"
+	align="horiz. right"
+}
+text {
+	object {
+		x=398
+		y=539
+		width=160
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Sample Detection"
+}
+"text update" {
+	object {
+		x=701
+		y=570
+		width=120
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)ScanDirection_RBV"
+		clr=54
+		bclr=4
+	}
+	format="string"
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=565
+		y=594
+		width=130
+		height=20
+	}
+	control {
+		chan="$(P)$(R)MinTipHeight"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=701
+		y=595
+		width=120
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)MinTipHeight_RBV"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+text {
+	object {
+		x=405
+		y=569
+		width=150
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Scan direction"
+	align="horiz. right"
+}
+text {
+	object {
+		x=405
+		y=594
+		width=150
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Min. tip height"
+	align="horiz. right"
+}
+menu {
+	object {
+		x=565
+		y=569
+		width=130
+		height=20
+	}
+	control {
+		chan="$(P)$(R)ScanDirection"
+		clr=14
+		bclr=51
+	}
+}
+rectangle {
+	object {
+		x=132
+		y=37
+		width=127
+		height=21
+	}
+	"basic attribute" {
+		clr=2
+	}
+}
+text {
+	object {
+		x=135
+		y=38
+		width=120
+		height=20
+	}
+	"basic attribute" {
+		clr=54
+	}
+	textix="NDPluginBase"
+	align="horiz. centered"
+}
+rectangle {
+	object {
+		x=5
+		y=35
+		width=380
+		height=31
+	}
+	"basic attribute" {
+		clr=14
+		fill="outline"
+	}
+}
+rectangle {
+	object {
+		x=6
+		y=63
+		width=379
+		height=5
+	}
+	"basic attribute" {
+		clr=4
+	}
+}
+polyline {
+	object {
+		x=841
+		y=390
+		width=391
+		height=0
+	}
+	"basic attribute" {
+		clr=10
+		fill="outline"
+	}
+	points {
+		(841,390)
+		(1232,390)
+	}
+}
+polyline {
+	object {
+		x=841
+		y=450
+		width=391
+		height=0
+	}
+	"basic attribute" {
+		clr=10
+		fill="outline"
+	}
+	points {
+		(841,450)
+		(1232,450)
+	}
+}
+polyline {
+	object {
+		x=841
+		y=280
+		width=391
+		height=0
+	}
+	"basic attribute" {
+		clr=10
+		fill="outline"
+	}
+	points {
+		(841,280)
+		(1232,280)
+	}
+}
+polyline {
+	object {
+		x=398
+		y=280
+		width=423
+		height=0
+	}
+	"basic attribute" {
+		clr=10
+		fill="outline"
+	}
+	points {
+		(398,280)
+		(821,280)
+	}
+}
+polyline {
+	object {
+		x=398
+		y=390
+		width=423
+		height=0
+	}
+	"basic attribute" {
+		clr=10
+		fill="outline"
+	}
+	points {
+		(398,390)
+		(821,390)
+	}
+}
+polyline {
+	object {
+		x=398
+		y=475
+		width=423
+		height=0
+	}
+	"basic attribute" {
+		clr=10
+		fill="outline"
+	}
+	points {
+		(398,475)
+		(821,475)
+	}
+}
+polyline {
+	object {
+		x=398
+		y=560
+		width=423
+		height=0
+	}
+	"basic attribute" {
+		clr=10
+		fill="outline"
+	}
+	points {
+		(398,560)
+		(821,560)
+	}
+}

--- a/adPythonApp/opi/adl/adPythonMxSampleDetectPlot.adl
+++ b/adPythonApp/opi/adl/adPythonMxSampleDetectPlot.adl
@@ -1,0 +1,195 @@
+
+file {
+	name="adPythonMxSampleDetectPlot.adl"
+	version=030109
+}
+display {
+	object {
+		x=293
+		y=174
+		width=840
+		height=539
+	}
+	clr=14
+	bclr=4
+	cmap=""
+	gridSpacing=5
+	gridOn=0
+	snapToGrid=0
+}
+"color map" {
+	ncolors=65
+	colors {
+		ffffff,
+		ececec,
+		dadada,
+		c8c8c8,
+		bbbbbb,
+		aeaeae,
+		9e9e9e,
+		919191,
+		858585,
+		787878,
+		696969,
+		5a5a5a,
+		464646,
+		2d2d2d,
+		000000,
+		00d800,
+		1ebb00,
+		339900,
+		2d7f00,
+		216c00,
+		fd0000,
+		de1309,
+		be190b,
+		a01207,
+		820400,
+		5893ff,
+		597ee1,
+		4b6ec7,
+		3a5eab,
+		27548d,
+		fbf34a,
+		f9da3c,
+		eeb62b,
+		e19015,
+		cd6100,
+		ffb0ff,
+		d67fe2,
+		ae4ebc,
+		8b1a96,
+		610a75,
+		a4aaff,
+		8793e2,
+		6a73c1,
+		4d52a4,
+		343386,
+		c7bb6d,
+		b79d5c,
+		a47e3c,
+		7d5627,
+		58340f,
+		99ffff,
+		73dfff,
+		4ea5f9,
+		2a63e4,
+		0a00b8,
+		ebf1b5,
+		d4db9d,
+		bbc187,
+		a6a462,
+		8b8239,
+		73ff6b,
+		52da3b,
+		3cb420,
+		289315,
+		1a7309,
+	}
+}
+rectangle {
+	object {
+		x=0
+		y=4
+		width=840
+		height=25
+	}
+	"basic attribute" {
+		clr=2
+	}
+}
+text {
+	object {
+		x=0
+		y=5
+		width=840
+		height=25
+	}
+	"basic attribute" {
+		clr=54
+	}
+	textix="$(P)$(R)"
+	align="horiz. centered"
+}
+"cartesian plot" {
+	object {
+		x=5
+		y=35
+		width=830
+		height=460
+	}
+	plotcom {
+		title="$(P)$(R)Top, Bottom"
+		xlabel="X Pixel"
+		ylabel="Y Pixel"
+		clr=14
+		bclr=4
+	}
+	trace[0] {
+		ydata="$(P)$(R)Top"
+		data_clr=63
+		yaxis=0
+	}
+	trace[1] {
+		ydata="$(P)$(R)Bottom"
+		data_clr=54
+		yaxis=1
+	}
+	x_axis {
+		rangeStyle="auto-scale"
+	}
+	y1_axis {
+		rangeStyle="auto-scale"
+	}
+}
+text {
+	object {
+		x=12
+		y=507
+		width=40
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Key:"
+	align="horiz. right"
+}
+text {
+	object {
+		x=62
+		y=509
+		width=48
+		height=18
+	}
+	"basic attribute" {
+		clr=63
+	}
+	textix="Top"
+	align="horiz. centered"
+}
+text {
+	object {
+		x=120
+		y=509
+		width=48
+		height=18
+	}
+	"basic attribute" {
+		clr=54
+	}
+	textix="Bottom"
+	align="horiz. centered"
+}
+rectangle {
+	object {
+		x=5
+		y=500
+		width=170
+		height=34
+	}
+	"basic attribute" {
+		clr=14
+		fill="outline"
+	}
+}

--- a/adPythonApp/opi/adl/adPythonPlugin.adl
+++ b/adPythonApp/opi/adl/adPythonPlugin.adl
@@ -1,0 +1,347 @@
+
+file {
+	name="adPythonPlugin.adl"
+	version=030109
+}
+display {
+	object {
+		x=463
+		y=470
+		width=848
+		height=184
+	}
+	clr=14
+	bclr=4
+	cmap=""
+	gridSpacing=5
+	gridOn=0
+	snapToGrid=0
+}
+"color map" {
+	ncolors=65
+	colors {
+		ffffff,
+		ececec,
+		dadada,
+		c8c8c8,
+		bbbbbb,
+		aeaeae,
+		9e9e9e,
+		919191,
+		858585,
+		787878,
+		696969,
+		5a5a5a,
+		464646,
+		2d2d2d,
+		000000,
+		00d800,
+		1ebb00,
+		339900,
+		2d7f00,
+		216c00,
+		fd0000,
+		de1309,
+		be190b,
+		a01207,
+		820400,
+		5893ff,
+		597ee1,
+		4b6ec7,
+		3a5eab,
+		27548d,
+		fbf34a,
+		f9da3c,
+		eeb62b,
+		e19015,
+		cd6100,
+		ffb0ff,
+		d67fe2,
+		ae4ebc,
+		8b1a96,
+		610a75,
+		a4aaff,
+		8793e2,
+		6a73c1,
+		4d52a4,
+		343386,
+		c7bb6d,
+		b79d5c,
+		a47e3c,
+		7d5627,
+		58340f,
+		99ffff,
+		73dfff,
+		4ea5f9,
+		2a63e4,
+		0a00b8,
+		ebf1b5,
+		d4db9d,
+		bbc187,
+		a6a462,
+		8b8239,
+		73ff6b,
+		52da3b,
+		3cb420,
+		289315,
+		1a7309,
+	}
+}
+rectangle {
+	object {
+		x=366
+		y=2
+		width=117
+		height=21
+	}
+	"basic attribute" {
+		clr=2
+	}
+}
+text {
+	object {
+		x=7
+		y=57
+		width=220
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Python script pathname"
+	align="horiz. right"
+}
+"text entry" {
+	object {
+		x=237
+		y=57
+		width=604
+		height=20
+	}
+	control {
+		chan="$(P)$(R)Filename"
+		clr=14
+		bclr=51
+	}
+	format="string"
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=237
+		y=38
+		width=604
+		height=14
+	}
+	monitor {
+		chan="$(P)$(R)Filename_RBV"
+		clr=54
+		bclr=4
+	}
+	format="string"
+	limits {
+	}
+}
+text {
+	object {
+		x=369
+		y=3
+		width=110
+		height=20
+	}
+	"basic attribute" {
+		clr=54
+	}
+	textix="Python File"
+	align="horiz. centered"
+}
+text {
+	object {
+		x=7
+		y=82
+		width=220
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Class name"
+	align="horiz. right"
+}
+"text entry" {
+	object {
+		x=237
+		y=82
+		width=209
+		height=20
+	}
+	control {
+		chan="$(P)$(R)Classname"
+		clr=14
+		bclr=51
+	}
+	format="string"
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=452
+		y=83
+		width=389
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)Classname_RBV"
+		clr=54
+		bclr=4
+	}
+	format="string"
+	limits {
+	}
+}
+text {
+	object {
+		x=7
+		y=107
+		width=220
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Read file"
+	align="horiz. right"
+}
+"message button" {
+	object {
+		x=237
+		y=107
+		width=209
+		height=20
+	}
+	control {
+		chan="$(P)$(R)ReadFile"
+		clr=14
+		bclr=51
+	}
+	label="Read File"
+	press_msg="1"
+}
+text {
+	object {
+		x=452
+		y=108
+		width=389
+		height=18
+	}
+	"basic attribute" {
+		clr=30
+	}
+	"dynamic attribute" {
+		vis="if not zero"
+		calc="A"
+		chan="$(P)$(R)ReadFile_RBV"
+	}
+	textix="Reading"
+}
+text {
+	object {
+		x=452
+		y=108
+		width=389
+		height=18
+	}
+	"basic attribute" {
+		clr=63
+	}
+	"dynamic attribute" {
+		vis="if zero"
+		calc="A"
+		chan="$(P)$(R)ReadFile_RBV"
+	}
+	textix="Done"
+}
+text {
+	object {
+		x=7
+		y=132
+		width=220
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Plugin runtime"
+	align="horiz. right"
+}
+"text update" {
+	object {
+		x=237
+		y=133
+		width=208
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)Time_RBV"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+text {
+	object {
+		x=452
+		y=132
+		width=389
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="ms"
+}
+text {
+	object {
+		x=7
+		y=157
+		width=220
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Plugin status"
+	align="horiz. right"
+}
+"text update" {
+	object {
+		x=237
+		y=158
+		width=208
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)PluginState_RBV"
+		clr=54
+		bclr=12
+	}
+	clrmod="alarm"
+	format="string"
+	limits {
+	}
+}
+rectangle {
+	object {
+		x=0
+		y=0
+		width=848
+		height=184
+	}
+	"basic attribute" {
+		clr=14
+		fill="outline"
+	}
+}


### PR DESCRIPTION
Here's a screenshot of adPythonMxSampleDetect.adl (which includes adPythonPlugin.adl):

<img width="1263" alt="adpythonmxsampledetect" src="https://user-images.githubusercontent.com/959381/45244501-b466d000-b2bd-11e8-91c5-5eebac602386.png">

And here's a screenshot of adPythonMxSampleDetectPlot.adl:

<img width="858" alt="adpythonmxsampledetectplot" src="https://user-images.githubusercontent.com/959381/45244549-eaa44f80-b2bd-11e8-852d-70af67abfd76.png">