### PR TITLE
Fix file resource leak in makePyInst

### DIFF
--- a/adPythonApp/src/adPythonPlugin.py
+++ b/adPythonApp/src/adPythonPlugin.py
@@ -18,13 +18,13 @@ def makePyInst(portname, filename, classname):
     log.setLevel(logging.INFO) 
     log.info("Creating %s:%s with portname %s", 
         os.path.basename(filename), classname, portname)
+    f = None
     try:
         # This dance is needed to load a file explicitly from a filename
         f = open(filename)
         pymodule, ext = os.path.splitext(os.path.basename(filename))
         AdPythonPlugin.log = log        
         mod = imp.load_module(pymodule, f, filename, (ext, 'U', 1))
-        f.close()
         # Get classname ref from this module and make an instance of it
         inst = getattr(mod, classname)()
         # Call paramChanged it might do some useful setup
@@ -35,6 +35,9 @@ def makePyInst(portname, filename, classname):
         # exception text
         log.exception("Creating %s:%s threw exception", filename, classname)
         raise
+    finally:
+        if f is not None:
+            f.close()
 
 class AdPythonPlugin(object):   
     # Will be our param dict


### PR DESCRIPTION
In the makePyInst function in adPythonPlugin.py, the file f will not be
closed if an exception is raised before the f.close() four lines later.
Move the close to a finally block to ensure the file always gets closed.