### PR TITLE
Upgrade to ADCore R3-0

### DIFF
--- a/adPythonApp/src/Makefile
+++ b/adPythonApp/src/Makefile
@@ -57,4 +57,6 @@ endif
 
 USR_CXXFLAGS += -DDATADIRS=\"$(shell cd ..; pwd):$(shell cd ../../scripts; pwd)\"
 
+include $(ADCORE)/ADApp/commonLibraryMakefile
+
 include $(TOP)/configure/RULES

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -31,3 +31,12 @@ CROSS_COMPILER_TARGET_ARCHS =
 # You must rebuild in the iocBoot directory for this to
 #   take effect.
 #IOCS_APPL_TOP = </IOC/path/to/application/top>
+
+# Get settings from AREA_DETECTOR, so that we only have to configure once
+-include $(AREA_DETECTOR)/configure/CONFIG_SITE
+-include $(AREA_DETECTOR)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH)
+-include $(AREA_DETECTOR)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+ifdef T_A
+  -include $(AREA_DETECTOR)/configure/CONFIG_SITE.Common.$(T_A)
+  -include $(AREA_DETECTOR)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+endif

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -19,17 +19,14 @@
 # Build settings that are NOT module paths should appear in a
 # CONFIG_SITE file.
 
-TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top
-SUPPORT=/dls_sw/prod/R3.14.12.3/support
+-include $(TOP)/../configure/RELEASE_LIBS_INCLUDE
+-include $(TOP)/RELEASE.local
+-include $(TOP)/configure/RELEASE.local
+
 WORK=/dls_sw/work/R3.14.12.3/support
 TOOLS_BASE=/dls_sw/prod/tools/RHEL6-x86_64
 
-ASYN=$(SUPPORT)/asyn/4-26
-ADCORE=$(SUPPORT)/ADCore/2-4dls8
 PYTHON_PREFIX=$(TOOLS_BASE)/Python/2-7-3/prefix
-
-# EPICS_BASE usually appears last so other apps can override stuff:
-EPICS_BASE=/dls_sw/epics/R3.14.12.3/base
 
 # Set RULES here if you want to take build rules from somewhere
 # other than EPICS_BASE:


### PR DESCRIPTION
Fix the plugin constructor arguments to the super constructor by
removing numParams and adding maxThreads.  (These ADCore changes were
introduced in R3-0 in commit 3af87bd.)

Fix the super call in processCallbacks to call NDPluginDriver's
beginProcessCallbacks method since processCallbacks in NDPluginDriver
was renamed to beginProcessCallbacks.  (This ADCore change was
introduced in R3-0 in commit 3af87bd.)

Call start() in adPythonPluginConfigure.  (The start method was added in
ADCore in R2-5 in commit b1a2f13.)