### PR TITLE
Avoid undefined NPY_INTERNAL_BUILD NumPy error

### DIFF
--- a/adPythonApp/src/adPythonPlugin.cpp
+++ b/adPythonApp/src/adPythonPlugin.cpp
@@ -6,6 +6,9 @@
 #include <Python.h>
 #define PYTHON_USE_NUMPY
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+// Workaround for building against NumPy with -Wall -Wundef -Werror; not
+// needed if NumPy contains commit c6566b7.
+#define NPY_INTERNAL_BUILD 0
 #include "numpy/ndarrayobject.h"
 #include <stdio.h>
 #include <libgen.h>


### PR DESCRIPTION
Work around an undefined NPY_INTERNAL_BUILD macro error

  /tmp/python-2.7.15/lib/python2.7/site-packages/numpy/core/include/numpy/npy_common.h:17:5: error: "NPY_INTERNAL_BUILD" is not defined
  cc1plus: warnings being treated as errors

when compiling with GCC 4.4.7 on RHEL 6 with -Wall -Wundef -Werror.

The NumPy issue is fixed in NumPy commit c6566b7.  This workaround will
work with or without NumPy commit c6566b7.  If the minimum version of
NumPy required by adPython is known to contain commit c6566b7, this
workaround can be removed.