### PR TITLE
Horizontal and vertical mx sample detect

### DIFF
--- a/adPythonApp/Db/adPythonMxSampleDetect.template
+++ b/adPythonApp/Db/adPythonMxSampleDetect.template
@@ -203,20 +203,28 @@ record(mbbo, "$(P)$(R)ScanDirection") {
     field(DTYP, "asynInt32")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))scan_direction")
 
-    field(ZRST, "Left to right")
-    field(ZRVL, "1")
-    field(ONST, "Right to left")
-    field(ONVL, "-1")
+    field(ZRST, "Right to left")
+    field(ZRVL, "0")
+    field(ONST, "Bottom to top")
+    field(ONVL, "1")
+    field(TWST, "Left to right")
+    field(TWVL, "2")
+    field(THST, "Top to bottom")
+    field(THVL, "3")
 }
 record(mbbi, "$(P)$(R)ScanDirection_RBV") {
     field(SCAN, "I/O Intr")
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))scan_direction")
 
-    field(ZRST, "Left to right")
-    field(ZRVL, "1")
-    field(ONST, "Right to left")
-    field(ONVL, "-1")
+    field(ZRST, "Right to left")
+    field(ZRVL, "0")
+    field(ONST, "Bottom to top")
+    field(ONVL, "1")
+    field(TWST, "Left to right")
+    field(TWVL, "2")
+    field(THST, "Top to bottom")
+    field(THVL, "3")
 }
 
 record(longout, "$(P)$(R)MinTipHeight") {

--- a/adPythonApp/scripts/adPythonMxSampleDetect.py
+++ b/adPythonApp/scripts/adPythonMxSampleDetect.py
@@ -136,7 +136,7 @@ def locate_sample(edge_arr, params):
     start = [None]*width
     end = [None]*width
 
-    if direction == LEFT_TO_RIGHT or direction == TOP_TO_BOTTOM:
+    if direction in (LEFT_TO_RIGHT, TOP_TO_BOTTOM):
         cross_section = xrange(width)
         move = FORWARD
     else:

--- a/adPythonApp/scripts/adPythonMxSampleDetect.py
+++ b/adPythonApp/scripts/adPythonMxSampleDetect.py
@@ -125,7 +125,7 @@ def locate_sample(edge_arr, params):
     # mxSampleDetect.
 
     direction, min_tip_height = params[:2]
-    vertical = direction == BOTTOM_TO_TOP or direction == TOP_TO_BOTTOM
+    vertical = direction in (BOTTOM_TO_TOP, TOP_TO_BOTTOM)
 
     # Index into edges_arr like [y, x], not [x, y]!
     height, width = edge_arr.shape


### PR DESCRIPTION
Hello,

Mark Williams and I have refactored the adPythonMxSampleDetect.py to make it work with both vertical and horizontal goniometers.

We have tested it on both I03 (horizontal) and I24 (vertical)

There is also an accompanying change to adPythonMxSampleDetect.template to provide 4 options on the direction drop-down list (left to right, right to left, top to bottom, bottom to top)

Thanks,

James
