### PR TITLE
Increase size of waveforms

### DIFF
--- a/adPythonApp/Db/adPythonMxSampleDetect.template
+++ b/adPythonApp/Db/adPythonMxSampleDetect.template
@@ -259,7 +259,7 @@ record(waveform, "$(P)$(R)Top")
    field(DTYP, "asynInt32ArrayIn")
    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))top")
    field(FTVL, "LONG")
-   field(NELM, "1024")
+   field(NELM, "2048")
 }
 record(waveform, "$(P)$(R)Bottom")
 {
@@ -267,7 +267,7 @@ record(waveform, "$(P)$(R)Bottom")
    field(DTYP, "asynInt32ArrayIn")
    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))bottom")
    field(FTVL, "LONG")
-   field(NELM, "1024")
+   field(NELM, "2048")
 }
 
 record(mbbo, "$(P)$(R)OutputArray") {

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -25,7 +25,7 @@ WORK=/dls_sw/work/R3.14.12.7/support
 TOOLS_BASE=/dls_sw/prod/tools/RHEL7-x86_64
 
 ASYN = $(SUPPORT)/asyn/4-41
-ADCORE = $(SUPPORT)/ADCore/3-12-1dls1
+ADCORE = $(SUPPORT)/ADCore/3-12-1dls2
 PYTHON_PREFIX=$(TOOLS_BASE)/Python/2-7-13/prefix
 
 # EPICS_BASE usually appears last so other apps can override stuff:

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -25,7 +25,7 @@ WORK=/dls_sw/work/R3.14.12.7/support
 TOOLS_BASE=/dls_sw/prod/tools/RHEL7-x86_64
 
 ASYN = $(SUPPORT)/asyn/4-41
-ADCORE = $(SUPPORT)/ADCore/3-11dls3
+ADCORE = $(SUPPORT)/ADCore/3-12-1dls1
 PYTHON_PREFIX=$(TOOLS_BASE)/Python/2-7-13/prefix
 
 # EPICS_BASE usually appears last so other apps can override stuff:


### PR DESCRIPTION
Increasing the NELM field of two waveform records used by the MX sample centering template.  The modern cameras require a bigger array size, but unfortunately these fields are not dynamic so require new magic numbers

This pull request also includes 2 other commits from GitLab, which are bumping the version of the ADCore dependency